### PR TITLE
fix: standardize logo height across ForgotPassword, SignUp, and VerifyCode components

### DIFF
--- a/src/pages/ForgotPassword.tsx
+++ b/src/pages/ForgotPassword.tsx
@@ -49,7 +49,7 @@ export const ForgotPassword = () => {
         <div className="max-w-md w-full mx-auto lg:mx-0 xl:mx-auto">
           {/* Logo */}
           <div className="mb-12 flex justify-center w-full">
-            <img src={Logo} alt="Certify Logo" className="h-[60px] absolute top-4 left-1/2 -translate-x-1/2" />
+            <img src={Logo} alt="Certify Logo" className="h-[4.5rem]" />
           </div>
 
           <h1 className="text-2xl lg:text-3xl font-bold mb-3 text-[#0e0393]">Esqueci minha senha</h1>

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -15,8 +15,9 @@ export const SignUpForm = () => {
     <div className="w-full bg-[#F2F2F9] flex flex-col-reverse lg:flex-row">
       <section className="flex-1 h-full w-full flex flex-col items-center">
         <div className="p-[30px]">
+           {/* Logo */}
           <div className='flex justify-center mb-18'>
-            <img src={LogoCertify} alt="Logo Certify" />
+            <img src={LogoCertify} alt="Logo Certify" className="h-[4.5rem]"/>
           </div>
 
           <h1 className="text-primary-blue-600 font-semibold text-[31px]">Criar conta</h1>

--- a/src/pages/VerifyCode.tsx
+++ b/src/pages/VerifyCode.tsx
@@ -121,7 +121,7 @@ export const VerifyCode = () => {
         <div className="max-w-md w-full mx-auto lg:mx-0 xl:mx-auto">
           {/* Logo */}
           <div className="mb-12 flex justify-center w-full">
-            <img src={Logo} alt="Certify Logo" className="h-[60px]" />
+            <img src={Logo} alt="Certify Logo" className="h-[4.5rem]" />
           </div>
 
           <h1 className="text-2xl lg:text-3xl font-bold mb-3 text-[#0e0393]">Esqueci minha senha</h1>


### PR DESCRIPTION
esssa pull request corrige a padronização da logo "certify" 
link do board no taiga ->https://tree.taiga.io/project/laridurao-liga-da-justica/us/97?milestone=523097 

alterei a logo das demais tela para o tamanho padrão da tela de login.

paginas corrigidas
tela de verificação
esqueci minha senha
criar conta 

como o bug foi corrigido
alterei o "classname" da  logo de cada classe para o tamanho padrão do projeto